### PR TITLE
Adding if block from /etc/X11/xinit/xinitrc

### DIFF
--- a/xinitrc
+++ b/xinitrc
@@ -5,3 +5,10 @@ else
     xbindkeys
     qtile start
 fi
+
+if [ -d /etc/X11/xinit/xinitrc.d ] ; then
+ for f in /etc/X11/xinit/xinitrc.d/?*.sh ; do
+  [ -x "$f" ] && . "$f"
+ done
+ unset f
+fi


### PR DESCRIPTION
Following instructions from xinit arch wiki (second note: https://wiki.archlinux.org/title/Xinit#xinitrc), last if block from /etc/X11/xinit/xinitrc is added to source scripts from xinitrc.d.